### PR TITLE
TimeZone / Daylight Saving Time

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phoenix344/opening-hours",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "lib/es6/cjs/OpeningHours.js",
   "module": "lib/es6/esm/OpeningHours.js",
   "types": "lib/es6/esm/OpeningHours.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phoenix344/opening-hours",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "main": "lib/es6/cjs/OpeningHours.js",
   "module": "lib/es6/esm/OpeningHours.js",
   "types": "lib/es6/esm/OpeningHours.d.ts",

--- a/src/OpeningHours.spec.ts
+++ b/src/OpeningHours.spec.ts
@@ -433,20 +433,14 @@ describe('state, isOpenSoon(), isClosedSoon()', () => {
     });
 });
 
-describe('timezone / daylight saving time', () => {
-    it('TimeZone/DST Check: Berlin: Mar 27, +01:00', () => {
-        const winterTime = '2021-03-27T10:30:00+0100';
-        const beforeFrom = new Date(winterTime);
-        beforeFrom.setMinutes(beforeFrom.getMinutes() - 1);
+describe('TimeZone/DST Check: Berlin: Mar 27, +01:00', () => {
+    let currentDate: string;
+    let openingHours: oh.OpeningHours;
 
-        const openTime = new Date(winterTime);
-        openTime.setMinutes(openTime.getMinutes() + 60);
-
-        const afterUntil = new Date(winterTime);
-        afterUntil.setMinutes(afterUntil.getMinutes() + 121);
-
-        const openingHours = new oh.OpeningHours({
-            currentDate: new Date(winterTime),
+    beforeEach(() => {
+        currentDate = '2021-03-27T10:30:00+0100';
+        openingHours = new oh.OpeningHours({
+            currentDate: new Date(currentDate),
             locales: 'de-DE',
             dateTimeFormatOptions: {
                 timeZone: 'Europe/Berlin',
@@ -454,27 +448,60 @@ describe('timezone / daylight saving time', () => {
                 minute: '2-digit',
             }
         });
-
         openingHours.add(oh.WeekDays.Saturday, '10:30', '12:30');
+    });
+
+    it('current day is active', () => {
+        const beforeFrom = new Date(currentDate);
+        beforeFrom.setMinutes(beforeFrom.getMinutes() - 1);
         expect(openingHours.toString()).toBe('[sat 10:30 - 12:30]');
-        expect(openingHours.getState(beforeFrom)).toBe(oh.OpenState.Closed);
-        expect(openingHours.getState(openTime)).toBe(oh.OpenState.Open);
-        expect(openingHours.getState(afterUntil)).toBe(oh.OpenState.Closed);
     });
 
-    it('TimeZone/DST Check: Berlin: Mar 28, +02:00', () => {
-        const summerTime = '2021-03-28T10:30:00+0200';
-        const beforeFrom = new Date(summerTime);
+    it('getState() = Closed, isOpenSoon() = true, isClosedSoon() = false', () => {
+        const beforeFrom = new Date(currentDate);
         beforeFrom.setMinutes(beforeFrom.getMinutes() - 1);
 
-        const openTime = new Date(summerTime);
+        expect(openingHours.getState(beforeFrom)).toBe(oh.OpenState.Closed);
+        expect(openingHours.isOpenSoon(beforeFrom)).toBeTruthy();
+        expect(openingHours.isClosedSoon(beforeFrom)).toBeFalsy();
+    });
+
+    it('getState() = Open, isOpenSoon() = false, isClosedSoon() = false', () => {
+        const openTime = new Date(currentDate);
         openTime.setMinutes(openTime.getMinutes() + 60);
 
-        const afterUntil = new Date(summerTime);
+        expect(openingHours.getState(openTime)).toBe(oh.OpenState.Open);
+        expect(openingHours.isOpenSoon(openTime)).toBeFalsy();
+        expect(openingHours.isClosedSoon(openTime)).toBeFalsy();
+    });
+
+    it('getState() = Open, isOpenSoon() = false, isClosedSoon() = true', () => {
+        const beforeUntil = new Date(currentDate);
+        beforeUntil.setMinutes(beforeUntil.getMinutes() + 119);
+
+        expect(openingHours.getState(beforeUntil)).toBe(oh.OpenState.Open);
+        expect(openingHours.isOpenSoon(beforeUntil)).toBeFalsy();
+        expect(openingHours.isClosedSoon(beforeUntil)).toBeTruthy();
+    });
+
+    it('getState() = Closed, isOpenSoon() = false, isClosedSoon() = false', () => {
+        const afterUntil = new Date(currentDate);
         afterUntil.setMinutes(afterUntil.getMinutes() + 121);
 
-        const openingHours = new oh.OpeningHours({
-            currentDate: new Date(summerTime),
+        expect(openingHours.getState(afterUntil)).toBe(oh.OpenState.Closed);
+        expect(openingHours.isOpenSoon(afterUntil)).toBeFalsy();
+        expect(openingHours.isClosedSoon(afterUntil)).toBeFalsy();
+    });
+});
+
+describe('TimeZone/DST Check: Berlin: Mar 28, +02:00', () => {
+    let currentDate: string;
+    let openingHours: oh.OpeningHours;
+
+    beforeEach(() => {
+        currentDate = '2021-03-28T10:30:00+0200';
+        openingHours = new oh.OpeningHours({
+            currentDate: new Date(currentDate),
             locales: 'de-DE',
             dateTimeFormatOptions: {
                 timeZone: 'Europe/Berlin',
@@ -482,27 +509,60 @@ describe('timezone / daylight saving time', () => {
                 minute: '2-digit',
             }
         });
-
         openingHours.add(oh.WeekDays.Sunday, '10:30', '12:30');
+    });
+
+    it('current day is active', () => {
+        const beforeFrom = new Date(currentDate);
+        beforeFrom.setMinutes(beforeFrom.getMinutes() - 1);
         expect(openingHours.toString()).toBe('[sun 10:30 - 12:30]');
-        expect(openingHours.getState(beforeFrom)).toBe(oh.OpenState.Closed);
-        expect(openingHours.getState(openTime)).toBe(oh.OpenState.Open);
-        expect(openingHours.getState(afterUntil)).toBe(oh.OpenState.Closed);
     });
 
-    it('TimeZone/DST Check: Melbourne: Apr 3, +11:00', () => {
-        const winterTime = '2021-04-03T10:30:00+1100';
-        const beforeFrom = new Date(winterTime);
+    it('getState() = Closed, isOpenSoon() = true, isClosedSoon() = false', () => {
+        const beforeFrom = new Date(currentDate);
         beforeFrom.setMinutes(beforeFrom.getMinutes() - 1);
 
-        const openTime = new Date(winterTime);
+        expect(openingHours.getState(beforeFrom)).toBe(oh.OpenState.Closed);
+        expect(openingHours.isOpenSoon(beforeFrom)).toBeTruthy();
+        expect(openingHours.isClosedSoon(beforeFrom)).toBeFalsy();
+    });
+
+    it('getState() = Open, isOpenSoon() = false, isClosedSoon() = false', () => {
+        const openTime = new Date(currentDate);
         openTime.setMinutes(openTime.getMinutes() + 60);
 
-        const afterUntil = new Date(winterTime);
+        expect(openingHours.getState(openTime)).toBe(oh.OpenState.Open);
+        expect(openingHours.isOpenSoon(openTime)).toBeFalsy();
+        expect(openingHours.isClosedSoon(openTime)).toBeFalsy();
+    });
+
+    it('getState() = Open, isOpenSoon() = false, isClosedSoon() = true', () => {
+        const beforeUntil = new Date(currentDate);
+        beforeUntil.setMinutes(beforeUntil.getMinutes() + 119);
+
+        expect(openingHours.getState(beforeUntil)).toBe(oh.OpenState.Open);
+        expect(openingHours.isOpenSoon(beforeUntil)).toBeFalsy();
+        expect(openingHours.isClosedSoon(beforeUntil)).toBeTruthy();
+    });
+
+    it('getState() = Closed, isOpenSoon() = false, isClosedSoon() = false', () => {
+        const afterUntil = new Date(currentDate);
         afterUntil.setMinutes(afterUntil.getMinutes() + 121);
 
-        const openingHours = new oh.OpeningHours({
-            currentDate: new Date(winterTime),
+        expect(openingHours.getState(afterUntil)).toBe(oh.OpenState.Closed);
+        expect(openingHours.isOpenSoon(afterUntil)).toBeFalsy();
+        expect(openingHours.isClosedSoon(afterUntil)).toBeFalsy();
+    });
+});
+
+describe('TimeZone/DST Check: Melbourne: Apr 3, +11:00', () => {
+    let currentDate: string;
+    let openingHours: oh.OpeningHours;
+
+    beforeEach(() => {
+        currentDate = '2021-04-03T10:30:00+1100';
+        openingHours = new oh.OpeningHours({
+            currentDate: new Date(currentDate),
             locales: 'en-AU',
             dateTimeFormatOptions: {
                 timeZone: 'Australia/Melbourne',
@@ -511,27 +571,60 @@ describe('timezone / daylight saving time', () => {
                 minute: '2-digit',
             }
         });
-
         openingHours.add(oh.WeekDays.Saturday, '10:30', '12:30');
-        expect(openingHours.toString()).toBe('[sat 10:30 am - 12:30 pm]');
-        expect(openingHours.getState(beforeFrom)).toBe(oh.OpenState.Closed);
-        expect(openingHours.getState(openTime)).toBe(oh.OpenState.Open);
-        expect(openingHours.getState(afterUntil)).toBe(oh.OpenState.Closed);
     });
 
-    it('TimeZone/DST Check: Melbourne: Apr 4, +10:00', () => {
-        const summerTime = '2021-04-04T10:30:00+1000';
-        const beforeFrom = new Date(summerTime);
+    it('current day is active', () => {
+        const beforeFrom = new Date(currentDate);
+        beforeFrom.setMinutes(beforeFrom.getMinutes() - 1);
+        expect(openingHours.toString()).toBe('[sat 10:30 am - 12:30 pm]');
+    });
+
+    it('getState() = Closed, isOpenSoon() = true, isClosedSoon() = false', () => {
+        const beforeFrom = new Date(currentDate);
         beforeFrom.setMinutes(beforeFrom.getMinutes() - 1);
 
-        const openTime = new Date(summerTime);
+        expect(openingHours.getState(beforeFrom)).toBe(oh.OpenState.Closed);
+        expect(openingHours.isOpenSoon(beforeFrom)).toBeTruthy();
+        expect(openingHours.isClosedSoon(beforeFrom)).toBeFalsy();
+    });
+
+    it('getState() = Open, isOpenSoon() = false, isClosedSoon() = false', () => {
+        const openTime = new Date(currentDate);
         openTime.setMinutes(openTime.getMinutes() + 60);
 
-        const afterUntil = new Date(summerTime);
+        expect(openingHours.getState(openTime)).toBe(oh.OpenState.Open);
+        expect(openingHours.isOpenSoon(openTime)).toBeFalsy();
+        expect(openingHours.isClosedSoon(openTime)).toBeFalsy();
+    });
+
+    it('getState() = Open, isOpenSoon() = false, isClosedSoon() = true', () => {
+        const beforeUntil = new Date(currentDate);
+        beforeUntil.setMinutes(beforeUntil.getMinutes() + 119);
+
+        expect(openingHours.getState(beforeUntil)).toBe(oh.OpenState.Open);
+        expect(openingHours.isOpenSoon(beforeUntil)).toBeFalsy();
+        expect(openingHours.isClosedSoon(beforeUntil)).toBeTruthy();
+    });
+
+    it('getState() = Closed, isOpenSoon() = false, isClosedSoon() = false', () => {
+        const afterUntil = new Date(currentDate);
         afterUntil.setMinutes(afterUntil.getMinutes() + 121);
 
-        const openingHours = new oh.OpeningHours({
-            currentDate: new Date(summerTime),
+        expect(openingHours.getState(afterUntil)).toBe(oh.OpenState.Closed);
+        expect(openingHours.isOpenSoon(afterUntil)).toBeFalsy();
+        expect(openingHours.isClosedSoon(afterUntil)).toBeFalsy();
+    });
+});
+
+describe('TimeZone/DST Check: Melbourne: Apr 4, +10:00', () => {
+    let currentDate: string;
+    let openingHours: oh.OpeningHours;
+
+    beforeEach(() => {
+        currentDate = '2021-04-04T10:30:00+1000';
+        openingHours = new oh.OpeningHours({
+            currentDate: new Date(currentDate),
             locales: 'en-AU',
             dateTimeFormatOptions: {
                 timeZone: 'Australia/Melbourne',
@@ -540,11 +633,48 @@ describe('timezone / daylight saving time', () => {
                 minute: '2-digit',
             }
         });
-
         openingHours.add(oh.WeekDays.Sunday, '10:30', '12:30');
+    });
+
+    it('current day is active', () => {
+        const beforeFrom = new Date(currentDate);
+        beforeFrom.setMinutes(beforeFrom.getMinutes() - 1);
         expect(openingHours.toString()).toBe('[sun 10:30 am - 12:30 pm]');
+    });
+
+    it('getState() = Closed, isOpenSoon() = true, isClosedSoon() = false', () => {
+        const beforeFrom = new Date(currentDate);
+        beforeFrom.setMinutes(beforeFrom.getMinutes() - 1);
+
         expect(openingHours.getState(beforeFrom)).toBe(oh.OpenState.Closed);
+        expect(openingHours.isOpenSoon(beforeFrom)).toBeTruthy();
+        expect(openingHours.isClosedSoon(beforeFrom)).toBeFalsy();
+    });
+
+    it('getState() = Open, isOpenSoon() = false, isClosedSoon() = false', () => {
+        const openTime = new Date(currentDate);
+        openTime.setMinutes(openTime.getMinutes() + 60);
+
         expect(openingHours.getState(openTime)).toBe(oh.OpenState.Open);
+        expect(openingHours.isOpenSoon(openTime)).toBeFalsy();
+        expect(openingHours.isClosedSoon(openTime)).toBeFalsy();
+    });
+
+    it('getState() = Open, isOpenSoon() = false, isClosedSoon() = true', () => {
+        const beforeUntil = new Date(currentDate);
+        beforeUntil.setMinutes(beforeUntil.getMinutes() + 119);
+
+        expect(openingHours.getState(beforeUntil)).toBe(oh.OpenState.Open);
+        expect(openingHours.isOpenSoon(beforeUntil)).toBeFalsy();
+        expect(openingHours.isClosedSoon(beforeUntil)).toBeTruthy();
+    });
+
+    it('getState() = Closed, isOpenSoon() = false, isClosedSoon() = false', () => {
+        const afterUntil = new Date(currentDate);
+        afterUntil.setMinutes(afterUntil.getMinutes() + 121);
+
         expect(openingHours.getState(afterUntil)).toBe(oh.OpenState.Closed);
+        expect(openingHours.isOpenSoon(afterUntil)).toBeFalsy();
+        expect(openingHours.isClosedSoon(afterUntil)).toBeFalsy();
     });
 });

--- a/src/OpeningHours.spec.ts
+++ b/src/OpeningHours.spec.ts
@@ -121,7 +121,7 @@ describe('options test', () => {
         openingHours.add(oh.WeekDays.Monday, '0330', '0500');
         openingHours.add(oh.WeekDays.Monday, '0700', '0800');
         openingHours.add(oh.WeekDays.Monday, '0600', '0900');
-        
+
         expect(openingHours.toString()).toBe(
             'mon 00:00 - 02:00, 03:00 - 05:00, 06:00 - 09:00'
         );
@@ -239,7 +239,7 @@ describe('cut(weekDay, "h:mm", "h:mm")', () => {
             { "day": 6, "from": "0800", "until": "1600" }
         ]);
         expect(openingHours.toString()).toBe(
-            'mon 08:00 - 16:00\n' + 
+            'mon 08:00 - 16:00\n' +
             'tue 08:00 - 16:00\n' +
             'wed 08:00 - 16:00\n' +
             'thu 08:00 - 16:00\n' +
@@ -269,7 +269,7 @@ describe('cut(weekDay, "h:mm", "h:mm")', () => {
         ]);
 
         expect(openingHours.toString()).toBe(
-            'mon 08:00 - 12:30, 13:00 - 16:00\n' + 
+            'mon 08:00 - 12:30, 13:00 - 16:00\n' +
             'tue 08:00 - 12:30, 13:00 - 16:00\n' +
             'wed 08:00 - 14:00\n' +
             'thu 08:00 - 12:30, 13:00 - 16:00\n' +
@@ -430,5 +430,121 @@ describe('state, isOpenSoon(), isClosedSoon()', () => {
         ]);
         expect(openingHours.isClosedSoon(new Date(2020, 8, 7, 16, 30), 900)).toBeFalsy();
         expect(openingHours.isClosedSoon(new Date(2020, 8, 7, 16, 46), 900)).toBeTruthy();
+    });
+});
+
+describe('timezone / daylight saving time', () => {
+    it('TimeZone/DST Check: Berlin: Mar 27, +01:00', () => {
+        const winterTime = '2021-03-27T10:30:00+0100';
+        const beforeFrom = new Date(winterTime);
+        beforeFrom.setMinutes(beforeFrom.getMinutes() - 1);
+
+        const openTime = new Date(winterTime);
+        openTime.setMinutes(openTime.getMinutes() + 60);
+
+        const afterUntil = new Date(winterTime);
+        afterUntil.setMinutes(afterUntil.getMinutes() + 121);
+
+        const openingHours = new oh.OpeningHours({
+            currentDate: new Date(winterTime),
+            locales: 'de-DE',
+            dateTimeFormatOptions: {
+                timeZone: 'Europe/Berlin',
+                hour: '2-digit',
+                minute: '2-digit',
+            }
+        });
+
+        openingHours.add(oh.WeekDays.Saturday, '10:30', '12:30');
+        expect(openingHours.toString()).toBe('[sat 10:30 - 12:30]');
+        expect(openingHours.getState(beforeFrom)).toBe(oh.OpenState.Closed);
+        expect(openingHours.getState(openTime)).toBe(oh.OpenState.Open);
+        expect(openingHours.getState(afterUntil)).toBe(oh.OpenState.Closed);
+    });
+
+    it('TimeZone/DST Check: Berlin: Mar 28, +02:00', () => {
+        const summerTime = '2021-03-28T10:30:00+0200';
+        const beforeFrom = new Date(summerTime);
+        beforeFrom.setMinutes(beforeFrom.getMinutes() - 1);
+
+        const openTime = new Date(summerTime);
+        openTime.setMinutes(openTime.getMinutes() + 60);
+
+        const afterUntil = new Date(summerTime);
+        afterUntil.setMinutes(afterUntil.getMinutes() + 121);
+
+        const openingHours = new oh.OpeningHours({
+            currentDate: new Date(summerTime),
+            locales: 'de-DE',
+            dateTimeFormatOptions: {
+                timeZone: 'Europe/Berlin',
+                hour: '2-digit',
+                minute: '2-digit',
+            }
+        });
+
+        openingHours.add(oh.WeekDays.Sunday, '10:30', '12:30');
+        expect(openingHours.toString()).toBe('[sun 10:30 - 12:30]');
+        expect(openingHours.getState(beforeFrom)).toBe(oh.OpenState.Closed);
+        expect(openingHours.getState(openTime)).toBe(oh.OpenState.Open);
+        expect(openingHours.getState(afterUntil)).toBe(oh.OpenState.Closed);
+    });
+
+    it('TimeZone/DST Check: Melbourne: Apr 3, +11:00', () => {
+        const winterTime = '2021-04-03T10:30:00+1100';
+        const beforeFrom = new Date(winterTime);
+        beforeFrom.setMinutes(beforeFrom.getMinutes() - 1);
+
+        const openTime = new Date(winterTime);
+        openTime.setMinutes(openTime.getMinutes() + 60);
+
+        const afterUntil = new Date(winterTime);
+        afterUntil.setMinutes(afterUntil.getMinutes() + 121);
+
+        const openingHours = new oh.OpeningHours({
+            currentDate: new Date(winterTime),
+            locales: 'en-AU',
+            dateTimeFormatOptions: {
+                timeZone: 'Australia/Melbourne',
+                hour12: true,
+                hour: '2-digit',
+                minute: '2-digit',
+            }
+        });
+
+        openingHours.add(oh.WeekDays.Saturday, '10:30', '12:30');
+        expect(openingHours.toString()).toBe('[sat 10:30 am - 12:30 pm]');
+        expect(openingHours.getState(beforeFrom)).toBe(oh.OpenState.Closed);
+        expect(openingHours.getState(openTime)).toBe(oh.OpenState.Open);
+        expect(openingHours.getState(afterUntil)).toBe(oh.OpenState.Closed);
+    });
+
+    it('TimeZone/DST Check: Melbourne: Apr 4, +10:00', () => {
+        const summerTime = '2021-04-04T10:30:00+1000';
+        const beforeFrom = new Date(summerTime);
+        beforeFrom.setMinutes(beforeFrom.getMinutes() - 1);
+
+        const openTime = new Date(summerTime);
+        openTime.setMinutes(openTime.getMinutes() + 60);
+
+        const afterUntil = new Date(summerTime);
+        afterUntil.setMinutes(afterUntil.getMinutes() + 121);
+
+        const openingHours = new oh.OpeningHours({
+            currentDate: new Date(summerTime),
+            locales: 'en-AU',
+            dateTimeFormatOptions: {
+                timeZone: 'Australia/Melbourne',
+                hour12: true,
+                hour: '2-digit',
+                minute: '2-digit',
+            }
+        });
+
+        openingHours.add(oh.WeekDays.Sunday, '10:30', '12:30');
+        expect(openingHours.toString()).toBe('[sun 10:30 am - 12:30 pm]');
+        expect(openingHours.getState(beforeFrom)).toBe(oh.OpenState.Closed);
+        expect(openingHours.getState(openTime)).toBe(oh.OpenState.Open);
+        expect(openingHours.getState(afterUntil)).toBe(oh.OpenState.Closed);
     });
 });

--- a/src/OpeningHours.ts
+++ b/src/OpeningHours.ts
@@ -119,8 +119,7 @@ export class OpeningHours {
         const current = this.normalizeLocalDate(now, timeZone);
         const day = current.getDay();
         for (const time of this.times[day]) {
-            const from = this.normalizeLocalDate(time.from);
-            const until = this.normalizeLocalDate(time.until);
+            const { from, until } = time;
             if (from <= current && until >= current) {
                 return OpenState.Open;
             }
@@ -143,8 +142,7 @@ export class OpeningHours {
         const soon = this.normalizeLocalDate(now, timeZone);
         soon.setSeconds(soon.getSeconds() + (elapseSeconds || 1800));
         for (const time of this.times[day]) {
-            const from = this.normalizeLocalDate(time.from);
-            const until = this.normalizeLocalDate(time.until);
+            const { from, until } = time;
             if ((from > current || until < current) && from <= soon && until >= soon) {
                 return true;
             }
@@ -167,8 +165,7 @@ export class OpeningHours {
         const soon = this.normalizeLocalDate(now, timeZone);
         soon.setSeconds(soon.getSeconds() + (elapseSeconds || 1800));
         for (const time of this.times[day]) {
-            const from = this.normalizeLocalDate(time.from);
-            const until = this.normalizeLocalDate(time.until);
+            const { from, until } = time;
             if ((from > soon || until < soon) && from <= current && until >= current) {
                 return true;
             }

--- a/src/OpeningHours.ts
+++ b/src/OpeningHours.ts
@@ -281,7 +281,7 @@ export class OpeningHours {
      */
     toLocaleJSON(options: OpeningHoursOptions = {}): OpenTimeResultOutput[] {
         options = { ...this.options, ...options };
-        const format = { ...options.dateTimeFormatOptions };
+        const format: Intl.DateTimeFormatOptions = { ...options.dateTimeFormatOptions };
         delete format.timeZone;
 
         const { currentDate, locales } = options;

--- a/src/OpeningHours.ts
+++ b/src/OpeningHours.ts
@@ -111,9 +111,17 @@ export class OpeningHours {
     }
 
     getState(now = new Date()) {
-        const day = now.getDay() as number;
+        // make sure the timeZone is set with a value.
+        // At least the local time of the current client.
+        const { timeZone } = Intl.DateTimeFormat(
+            this.options.locales,
+            this.options.dateTimeFormatOptions).resolvedOptions();
+        const current = this.normalizeLocalDate(now, timeZone);
+        const day = current.getDay();
         for (const time of this.times[day]) {
-            if (time.from <= now && time.until >= now) {
+            const from = this.normalizeLocalDate(time.from);
+            const until = this.normalizeLocalDate(time.until);
+            if (from <= current && until >= current) {
                 return OpenState.Open;
             }
         }
@@ -125,13 +133,19 @@ export class OpeningHours {
      * 1800 seconds.
      */
     isOpenSoon(now = new Date(), elapseSeconds?: number) {
-        const curr = now.getTime()
-        const soon = curr + ((elapseSeconds || 1800) * 1000);
-        const day = now.getDay() as number;
+        // make sure the timeZone is set with a value.
+        // At least the local time of the current client.
+        const { timeZone } = Intl.DateTimeFormat(
+            this.options.locales,
+            this.options.dateTimeFormatOptions).resolvedOptions();
+        const current = this.normalizeLocalDate(now, timeZone);
+        const day = current.getDay();
+        const soon = this.normalizeLocalDate(now, timeZone);
+        soon.setSeconds(soon.getSeconds() + (elapseSeconds || 1800));
         for (const time of this.times[day]) {
-            const from = time.from.getTime();
-            const until = time.until.getTime();
-            if ((from > curr || until < curr) && from <= soon && until >= soon) {
+            const from = this.normalizeLocalDate(time.from);
+            const until = this.normalizeLocalDate(time.until);
+            if ((from > current || until < current) && from <= soon && until >= soon) {
                 return true;
             }
         }
@@ -143,13 +157,19 @@ export class OpeningHours {
      * 1800 seconds.
      */
     isClosedSoon(now = new Date(), elapseSeconds?: number) {
-        const curr = now.getTime()
-        const soon = curr + ((elapseSeconds || 1800) * 1000);
-        const day = now.getDay() as number;
+        // make sure the timeZone is set with a value.
+        // At least the local time of the current client.
+        const { timeZone } = Intl.DateTimeFormat(
+            this.options.locales,
+            this.options.dateTimeFormatOptions).resolvedOptions();
+        const current = this.normalizeLocalDate(now, timeZone);
+        const day = current.getDay();
+        const soon = this.normalizeLocalDate(now, timeZone);
+        soon.setSeconds(soon.getSeconds() + (elapseSeconds || 1800));
         for (const time of this.times[day]) {
-            const from = time.from.getTime();
-            const until = time.until.getTime();
-            if ((from > soon || until < soon) && from <= curr && until >= curr) {
+            const from = this.normalizeLocalDate(time.from);
+            const until = this.normalizeLocalDate(time.until);
+            if ((from > soon || until < soon) && from <= current && until >= current) {
                 return true;
             }
         }
@@ -264,11 +284,21 @@ export class OpeningHours {
      */
     toLocaleJSON(options: OpeningHoursOptions = {}): OpenTimeResultOutput[] {
         options = { ...this.options, ...options };
+        const format = { ...options.dateTimeFormatOptions };
+        delete format.timeZone;
+
         const { currentDate, locales } = options;
         const { weekDays } = { ...this.text,  ...(options.text || {}) };
+
+        // make sure the timeZone is set with a value.
+        // At least the local time of the current client.
+        const { timeZone } = Intl.DateTimeFormat(
+            this.options.locales,
+            this.options.dateTimeFormatOptions).resolvedOptions();
+        const current = this.normalizeLocalDate(currentDate as Date, timeZone);
         const openTimes = [];
         for (const [day, times] of this.times.entries()) {
-            const active = currentDate?.getDay() === day;
+            const active = current.getDay() === day;
             if (times.length === 0) {
                 // create an object if showClosedDays is enabled.
                 openTimes[day] = options.showClosedDays ? {
@@ -284,8 +314,8 @@ export class OpeningHours {
                     day: weekDays[day],
                     times: times
                         .map(time => {
-                            const from = time.from.toLocaleTimeString(locales, options.dateTimeFormatOptions);
-                            const until = time.until.toLocaleTimeString(locales, options.dateTimeFormatOptions);
+                            const from = time.from.toLocaleTimeString(locales, format);
+                            const until = time.until.toLocaleTimeString(locales, format);
                             return { from, until };
                         }),
                 };
@@ -335,6 +365,14 @@ export class OpeningHours {
         return result.join('\n');
     }
 
+
+    private normalizeLocalDate(date: Date, timeZone?: string | undefined) {
+        // Hack: I'm using the "sv" locale from sweden,
+        // because it's similar to the ISO DateTime format.
+        const result = date.toLocaleString('sv', { timeZone });
+        return new Date(result.replace(' ', 'T'));
+    }
+
     /**
      * Creates a date object from currentDate and the given
      * opening hours time.
@@ -348,11 +386,12 @@ export class OpeningHours {
             date.getMinutes(),
             date.getSeconds()
         ];
-        const offset = day - now.getDay();
+        const dayOffset = day - now.getDay();
+        
         return new Date(
             now.getFullYear(),
             now.getMonth(),
-            now.getDate() + offset,
+            now.getDate() + dayOffset,
             hours,
             minutes,
             seconds


### PR DESCRIPTION
Bugfix for #3 

**The problem:** The Date Object doesn't provide a way to manipulate the timezone offset properly. It's true that we don't need an offset (as it was stated), but it's a bit of a hassle to get through it.

To translate the local time to a format that can be read by the Date class, I'm using the swedish "sv" locale. Afterwards I'm creating a new Date object to be able to compare both dates. (https://stackoverflow.com/a/65758103)
```
// internal local timezone is -06:00 for this example:

// both Date objects are calculating internally with the same timezone.
// If you want to do some operations based on this and display the remote
// time, you have to change the local time to the remote timezone.
localTime = new Date('2021-01-28T07:00:00');
// => '2021-01-28T13:00:00.000Z'

remoteTime = new Date('2021-01-28T08:00:00');
// => '2021-01-28T14:00:00.000Z'

// Translates the local time into New York time as a ISO datetime string
datetimestr = localTime.toLocaleString('sv', { timeZone: 'America/New_York' }).replace(' ', 'T');
// => '2021-01-28T08:00:00'

// Internally it will still be calculated on the level of the client:
new Date(datetimestr).toISOString(); // => '2021-01-28T14:00:00.000Z'
remoteTime.toISOString();            // => '2021-01-28T14:00:00.000Z'
```
Now I'm able to calculate with local and a remote times/dates - and it also provides support for daylight saving time natively.